### PR TITLE
docs(skill): 作者速查页补充指向 runtime 内置协议规范原文

### DIFF
--- a/skills/indesign-cli/references/html-authoring.md
+++ b/skills/indesign-cli/references/html-authoring.md
@@ -49,6 +49,10 @@ indesign-cli-agent tool call html.build_indesign --args-file build.args.json --t
 
 `mode: "draft"` 会跳过真实文档核对，结果始终是未验证草稿，不能作为正式成品。只需要 HTML 时，在严格检查通过后交付 `deck.html` 和完整作者包，不执行第 4 步。
 
+## 协议规范原文
+
+本页只是速查摘要。完整协议规范随 runtime 分发在每台机器上：`<runtime_root>\plugins\html-indesign\docs\规范\`（`runtime_root` 取 `indesign-cli-agent --json health` 返回的 `data.update.runtime_root`），含作者指南、语义协议、标签协议、字体策略、反向导出、库规格六份文档。遇到本页未覆盖的字段语义，查原文，不要猜。
+
 ## 作者规则
 
 硬要求：


### PR DESCRIPTION
## 背景

`skills/indesign-cli/references/html-authoring.md` 是自包含的 83 行速查摘要，全文没有指向完整协议规范的引用。而完整规范其实已随 runtime 分发到每台机器（`<runtime_root>\plugins\html-indesign\docs\规范\`，含作者指南/语义协议/标签协议/字体策略/反向导出/库规格六份）——agent 不知道它存在，遇到摘要未覆盖的字段语义只能猜。

实际影响（我们所内测试中遇到的例子）：`data-id-asset-path` 与预览双路引用、母版家具双字段、字符样式 token 的使用时机等，摘要都没有，agent 猜错后 lint/构建绿灯但产物降级。

## 改动

在"作者规则"节前加一小节"协议规范原文"：告诉 agent 规范就在本机 runtime 内、路径怎么拼（经 `health` 取 `runtime_root`）、遇到未覆盖的字段语义查原文不要猜。一行不改现有内容。

🤖 Generated with [Claude Code](https://claude.com/claude-code)